### PR TITLE
Add anchors to HTML document

### DIFF
--- a/src/components/page.js
+++ b/src/components/page.js
@@ -27,7 +27,7 @@ const Page = ({kataBundles}) =>
 const KataBundle = ({bundle}) =>
   html`
     <div>
-      <h2>${bundle.name}</h2>
+      <a href="#${bundle.anchor}" name="${bundle.anchor}"><h2>${bundle.name}</h2></a>
       ${bundle
         .allGroups()
         .map(group =>

--- a/src/katabundle.js
+++ b/src/katabundle.js
@@ -12,9 +12,10 @@ export default class KataBundle {
     return this.allGroups().length;
   }
 
-  static withGroups(name, rawGroups) {
+  static withGroups(name, anchor, rawGroups) {
     const bundle = new KataBundle();
     bundle.name = name;
+    bundle.anchor = anchor;
     bundle.initializePropertiesFromRawObject(rawGroups);
     bundle.sortByNumberOfLinks();
     bundle.moveGroupWithNewestKataToBeginning();

--- a/src/pagedata.js
+++ b/src/pagedata.js
@@ -16,6 +16,7 @@ export const loadKataBundles = async ({fetch}) => {
   const kataBundles = [];
   kataBundles.push(
     RawMetadata.toKataBundle({
+      anchor: 'es1',
       name: 'ECMAScript 1',
       metadata: bundlesMetadata[0],
       url: TDDBIN_URL + '#?kata=es1/language/',
@@ -23,6 +24,7 @@ export const loadKataBundles = async ({fetch}) => {
   );
   kataBundles.push(
     RawMetadata.toKataBundle({
+      anchor: 'es1rewrite',
       name: 'ECMAScript 1 - Learn by rewriting',
       metadata: bundlesMetadata[1],
       url: TDDBIN_URL + '#?kata=es1/learn-by-rewriting/',
@@ -30,6 +32,7 @@ export const loadKataBundles = async ({fetch}) => {
   );
   kataBundles.push(
     RawMetadata.toKataBundle({
+      anchor: 'es6',
       name: 'ECMAScript 6',
       metadata: bundlesMetadata[2],
       url: TDDBIN_URL + '#?kata=es6/language/',
@@ -37,6 +40,7 @@ export const loadKataBundles = async ({fetch}) => {
   );
   kataBundles.push(
     RawMetadata.toKataBundle({
+      anchor: 'es7',
       name: 'ECMAScript 7',
       metadata: bundlesMetadata[3],
       url: TDDBIN_URL + '#?kata=es7/language/',
@@ -44,6 +48,7 @@ export const loadKataBundles = async ({fetch}) => {
   );
   kataBundles.push(
     RawMetadata.toKataBundle({
+      anchor: 'es8',
       name: 'ECMAScript 8',
       metadata: bundlesMetadata[4],
       url: TDDBIN_URL + '#?kata=es8/language/',
@@ -51,6 +56,7 @@ export const loadKataBundles = async ({fetch}) => {
   );
   kataBundles.push(
     RawMetadata.toKataBundle({
+      anchor: 'es10',
       name: 'ECMAScript 10',
       metadata: bundlesMetadata[5],
       url: TDDBIN_URL + '#?kata=es10/language/',
@@ -58,6 +64,7 @@ export const loadKataBundles = async ({fetch}) => {
   );
   kataBundles.push(
     RawMetadata.toKataBundle({
+      anchor: 'hamjest',
       name: 'Assertion Library Hamjest',
       metadata: bundlesMetadata[6],
       url: TDDBIN_URL + '#?kata=libraries/hamjest/',

--- a/src/rawmetadata.js
+++ b/src/rawmetadata.js
@@ -12,9 +12,10 @@ const fromMetadataJsonToKataBundle = (groupedMetadataJson, url) => {
 };
 
 export default class RawMetadata {
-  static toKataBundle({name, metadata, url}) {
+  static toKataBundle({name, anchor, metadata, url}) {
     return KataBundle.withGroups(
       name,
+      anchor,
       fromMetadataJsonToKataBundle(metadata, url),
     );
   }

--- a/src/style.css
+++ b/src/style.css
@@ -4,7 +4,8 @@ body {
   margin: 0;
 }
 
-a h1 {
+a h1,
+a h2 {
   color: white;
 }
 a {

--- a/src/test/katabundle-spec.js
+++ b/src/test/katabundle-spec.js
@@ -17,8 +17,12 @@ class Kata {
 
 describe('KataBundle', () => {
   it('must provide the `name` as property', () => {
-    const bundle = KataBundle.withGroups('ES11', {});
+    const bundle = KataBundle.withGroups('ES11', '', {});
     assert.strictEqual(bundle.name, 'ES11');
+  });
+  it('must provide the `anchor` as property', () => {
+    const bundle = KataBundle.withGroups('', 'es11', {});
+    assert.strictEqual(bundle.anchor, 'es11');
   });
 });
 describe('sort kata groups', () => {


### PR DESCRIPTION
I’m using the ES6 Katas in teaching. It would be great if I could directly send the students to the right katas. Also, es6katas.org could redirect to https://jskatas.org/#es6 then.